### PR TITLE
.github ISSUE_TEMPLATES: add starter set of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'Bug: {short description}'
+labels: bug, needs triage
+assignees: ''
+
+---
+
+{Summary of bug}
+
+### Step(s) to Reproduce
+{Numbered list of step(s)}
+
+### Expected Result
+{Summary of expected result}
+
+### Actual Outcome
+{Description of actual outcome}

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea to add support for to this project
+title: 'Feature Request: {short description}'
+labels: enhancement, needs triage
+assignees: ''
+
+---
+
+{Detailed description}
+
+### Affected Functionality
+{Any known functionality impacted, or Unknown if further research needs to be done}
+
+### Other Relevant Issues
+{Links to Relevant Issues}

--- a/.github/ISSUE_TEMPLATE/suggest-a-task.md
+++ b/.github/ISSUE_TEMPLATE/suggest-a-task.md
@@ -1,0 +1,16 @@
+---
+name: Suggest a task
+about: Suggest an idea for improving this project without changing functionality
+title: 'Task: {short description}'
+labels: 'needs triage'
+assignees: ''
+
+---
+
+{Detailed description}
+
+### Affected Functionality
+{Any known functionality impacted, or Unknown if further research needs to be done}
+
+### Other Relevant Issues
+{Links to Relevant Issues}


### PR DESCRIPTION
# What is this?
Issue templates will make it easier for people to quickly contribute actionable reports and requests to the repo.

These templates taken from: https://github.com/zdylag/GoSeed/tree/main/.github/ISSUE_TEMPLATE

# What does this look like?
From the source repo:
![image](https://user-images.githubusercontent.com/13932684/189503900-75532448-d113-4296-be16-64bb09e8f84b.png)
